### PR TITLE
Allows for custom view attributes to be passed to CKMButtonComponent

### DIFF
--- a/ComponentKit/Components/Mac/CKMButtonComponent.h
+++ b/ComponentKit/Components/Mac/CKMButtonComponent.h
@@ -4,6 +4,8 @@
 
 @interface CKMButtonComponent : CKComponent
 
-+ (instancetype)newWithTitle:(NSString *)title target:(id)target action:(CKComponentAction)action;
++ (instancetype)newWithTitle:(NSString *)title
+                        type:(NSButtonType)type
+              viewAttributes:(CKViewComponentAttributeValueMap)viewAttributes;
 
 @end

--- a/Examples/SimpleMacApp/SimpleMacApp/CKMSampleComponentProvider.mm
+++ b/Examples/SimpleMacApp/SimpleMacApp/CKMSampleComponentProvider.mm
@@ -65,12 +65,13 @@
               children:{
                 {[CKMButtonComponent
                   newWithTitle:@"Flexible width"
-                  target:nil
-                  action:nil], .flexGrow = YES},
+                  type:NSMomentaryLightButton
+                  viewAttributes:{}],
+                  .flexGrow = YES},
                 {[CKMButtonComponent
                   newWithTitle:@"Fixed width"
-                  target:nil
-                  action:nil]},
+                  type:NSMomentaryLightButton
+                  viewAttributes:{}]},
               }],
             .spacingBefore = 5},
           }];

--- a/Examples/SimpleMacApp/SimpleMacApp/CKMTableCellComponentProvider.mm
+++ b/Examples/SimpleMacApp/SimpleMacApp/CKMTableCellComponentProvider.mm
@@ -35,8 +35,16 @@
             },
             {[CKMButtonComponent
               newWithTitle: @"Do Something"
-             target:nil
-             action:nil]},
+              type:NSMomentaryLightButton
+              viewAttributes:{}]},
+            {[CKMButtonComponent
+              newWithTitle: @"Checkbox!!"
+              type:NSSwitchButton
+              viewAttributes:{}]},
+            {[CKMButtonComponent
+              newWithTitle: @"Radio!!"
+              type:NSRadioButton
+              viewAttributes:{}]},
           }];
 
 }


### PR DESCRIPTION
Needed to pass additional view attributes into `CKMButtonComponent` (e.g. `keyEquivalent`). This updates the component to take additional attributes and removes the target/selector input as it should now be using `CKComponentActionAttribute`
