### PR TITLE
Update build settings and imports for table components

### DIFF
--- a/ComponentKit.podspec
+++ b/ComponentKit.podspec
@@ -27,5 +27,7 @@ Pod::Spec.new do |s|
   s.xcconfig = {
     'CLANG_CXX_LANGUAGE_STANDARD' => 'c++11',
     'CLANG_CXX_LIBRARY' => 'libc++',
+    'GCC_WARN_ABOUT_MISSING_PROTOTYPES' => 'YES',
+    'GCC_TREAT_WARNINGS_AS_ERRORS' => 'YES'
   }
 end

--- a/ComponentKit/ComponentKit.h
+++ b/ComponentKit/ComponentKit.h
@@ -17,7 +17,7 @@
 #import <ComponentKit/CKNetworkImageComponent.h>
 #import <ComponentKit/CKNetworkImageDownloading.h>
 #else
-
+#import <ComponentKit/CKMTableComponent.h>
 #endif
 #import <ComponentKit/CKImageComponent.h>
 

--- a/ComponentKit/Components/Mac/CKMTableComponent.h
+++ b/ComponentKit/Components/Mac/CKMTableComponent.h
@@ -1,6 +1,6 @@
 // Copyright 2004-present Facebook. All Rights Reserved.
 
-#import <ComponentKit/ComponentKit.h>
+#import <ComponentKit/CKComponent.h>
 
 /**
  * A simple component to add async NSTableViews to your other component layouts.

--- a/ComponentKit/Components/Mac/CKMTableComponent.mm
+++ b/ComponentKit/Components/Mac/CKMTableComponent.mm
@@ -1,9 +1,12 @@
 // Copyright 2004-present Facebook. All Rights Reserved.
 #import "CKMTableComponent.h"
 
+#import <ComponentKit/CKCompositeComponent.h>
+#import <ComponentKit/CKComponentController.h>
 #import <ComponentKit/CKComponentInternal.h>
 #import <ComponentKit/CKComponentSubclass.h>
 #import <ComponentKit/CKComponentMemoizer.h>
+#import <ComponentKit/CKComponentScope.h>
 #import <ComponentKit/CKNSTableViewDataSource.h>
 #import <ComponentKit/CKComponentViewInterface.h>
 #import <ComponentKit/CKTransactionalComponentDataSourceConfiguration.h>
@@ -163,7 +166,7 @@ static CKTransactionalComponentDataSourceChangeset *insertItems(NSArray *models,
   };
 }
 
-CKComponentDelegateForwarder *appendSelectorsToForwarder(CKComponentDelegateForwarder *existing, CKComponentForwardedSelectors selectors)
+NS_INLINE CKComponentDelegateForwarder *appendSelectorsToForwarder(CKComponentDelegateForwarder *existing, CKComponentForwardedSelectors selectors)
 {
   // Union our selectors with those of the existing delegate
   CKComponentForwardedSelectors neue = existing.selectors;

--- a/Examples/SimpleMacApp/Podfile.lock
+++ b/Examples/SimpleMacApp/Podfile.lock
@@ -9,6 +9,6 @@ EXTERNAL SOURCES:
     :path: ../..
 
 SPEC CHECKSUMS:
-  ComponentKit: 4b2ed4f0e6a684a284327b2da9e8801d05ded1cb
+  ComponentKit: 4f32a10bfdd7c02e73264e04346983589830bec3
 
 COCOAPODS: 0.38.2


### PR DESCRIPTION
- Updates componentkit to treat warnings as errors and to warn about missing function prototypes.
- Fixes build error by making c function inline
- Adds CKMTableComponent to the ComponentKit header and cleans up internal imports to only include relevant headers
